### PR TITLE
Disable automerge

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -150,5 +150,6 @@ runs:
             environment_url: `${{ steps.deploy.outputs.url }}`,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            deployment_id: deployment.data.id
+            deployment_id: deployment.data.id,
+            auto_merge: false
           });


### PR DESCRIPTION
## Whats New

We are now disabling `auto_merge` option which is true by default so we don't have to try and fail while automatically merging if the branch is behind from the main branch.

ref: https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment

```
auto_merge boolean
Attempts to automatically merge the default branch into the requested ref, if it's behind the default branch.
Default: true
```
