### PR TITLE
Dont allow underscore in the app tag.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
     - name: Get url friendly branch name
       shell: bash
       run: |
-        url=$(sed -E 's#refs/[^\/]*/##;s/[^a-zA-Z0-9_]+/-/g;s/-+/-/g;s/^-*//;s/-*$//' <<<"${GITHUB_HEAD_REF}")
+        url=$(sed -E 's#refs/[^\/]*/##;s/[^a-zA-Z0-9]+/-/g;s/-+/-/g;s/^-*//;s/-*$//' <<<"${GITHUB_HEAD_REF}")
         tolower=${url,,}
         reduce=$(echo $tolower | cut -c -20)
         echo "BRANCH_URL=$(echo ${reduce%-})" >> $GITHUB_ENV


### PR DESCRIPTION
## Whats New 

We are now cleaning `_` in the branch names while creating app tag since CloudRun doesn't like `_` in the tag names 
