### PR TITLE
chore: bump actions/github-script to v9

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -123,7 +123,7 @@ runs:
         env_vars: ${{ inputs.CLOUD_RUN_ENV_VARS }}
         secrets: ${{ inputs.CLOUD_RUN_SECRETS }}
     - name: Comment the Link on Pull Request
-      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       continue-on-error: true
       env:
         DEPLOY_URL: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
v6.4.1 targets Node 20, which runners now force onto Node 24. v9 runs on node24 natively. No config change needed: the only inputs we set are script/github-token, and v9's breaking changes (require('@actions/github') and the injected getOctokit) are not used by comment-pr.js.